### PR TITLE
fix: wrong type assumed for subprocess.POpen().communicate

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -52,3 +52,8 @@ coverage.xml
 # Sphinx documentation
 docs/_build/
 
+# Visual Studio Code IDE settings
+.vscode/
+
+# PyCharm IDE settings
+.idea/

--- a/miner/git_complexity_trend_test.py
+++ b/miner/git_complexity_trend_test.py
@@ -1,0 +1,22 @@
+import unittest
+import argparse
+
+import git_complexity_trend
+
+
+class GitComplexityTrendTest(unittest.TestCase):
+    def test_git_complexity_trend_should_process_file_under_test(self):
+        parser = argparse.ArgumentParser()
+        parser.add_argument('--start')
+        parser.add_argument('--end')
+        parser.add_argument('--file')
+
+        args = list(["--start", "89272ea", "--end", "30b449a", "--file", "./git_complexity_trend.py"])
+        args = parser.parse_args(args)
+
+        git_complexity_trend.run(args)
+        self.assertTrue(True, "Test should pass without throwing an error.")
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/miner/git_interactions.py
+++ b/miner/git_interactions.py
@@ -8,8 +8,12 @@ def _as_rev_range(start, end):
 
 
 def _run_git_cmd(git_arguments):
+    encoding = 'UTF-8'
+    if sys.stdout.encoding is not None:
+        encoding = sys.stdout.encoding
+
     stdout_bytes = subprocess.Popen(git_arguments, stdout=subprocess.PIPE).communicate()[0]
-    stdout = stdout_bytes.decode(sys.stdout.encoding)
+    stdout = stdout_bytes.decode(encoding)
     return stdout
 
 

--- a/miner/git_interactions.py
+++ b/miner/git_interactions.py
@@ -1,4 +1,5 @@
 import subprocess
+import sys
 import re
 
 
@@ -17,7 +18,9 @@ def _read_revisions_matching(git_arguments):
     # match a line like: d804759 Documented tree map visualizations
     # ignore everything except the commit number:
     rev_expr = re.compile(r'([^\s]+)')
-    for line in git_log.split("\n"):
+    encoding = sys.stdout.encoding
+    for line_bytes in git_log.split("\n".encode(encoding)):
+        line = line_bytes.decode(encoding)
         m = rev_expr.search(line)
         if m:
             revs.append(m.group(1))

--- a/miner/git_interactions.py
+++ b/miner/git_interactions.py
@@ -8,8 +8,9 @@ def _as_rev_range(start, end):
 
 
 def _run_git_cmd(git_arguments):
-    return subprocess.Popen(
-        git_arguments, stdout=subprocess.PIPE).communicate()[0]
+    stdout_bytes = subprocess.Popen(git_arguments, stdout=subprocess.PIPE).communicate()[0]
+    stdout = stdout_bytes.decode(sys.stdout.encoding)
+    return stdout
 
 
 def _read_revisions_matching(git_arguments):
@@ -18,9 +19,7 @@ def _read_revisions_matching(git_arguments):
     # match a line like: d804759 Documented tree map visualizations
     # ignore everything except the commit number:
     rev_expr = re.compile(r'([^\s]+)')
-    encoding = sys.stdout.encoding
-    for line_bytes in git_log.split("\n".encode(encoding)):
-        line = line_bytes.decode(encoding)
+    for line in git_log.split("\n"):
         m = rev_expr.search(line)
         if m:
             revs.append(m.group(1))

--- a/miner/git_interactions_test.py
+++ b/miner/git_interactions_test.py
@@ -1,0 +1,12 @@
+import unittest
+import subprocess
+
+class GitInteractionsTest(unittest.TestCase):
+    def test_reproduce_problem(self):
+        process_stdout = subprocess.Popen([ "echo", "first line\nsecond line" ], stdout=subprocess.PIPE).communicate()[0]
+        
+        lines = process_stdout.split("\n")
+        self.assertEqual(1, len(lines))
+
+if __name__ == '__main__':
+    unittest.main()

--- a/miner/git_interactions_test.py
+++ b/miner/git_interactions_test.py
@@ -1,19 +1,23 @@
 import unittest
 import subprocess
+import sys
+
 import git_interactions
 
 
 class GitInteractionsTest(unittest.TestCase):
-    def test_split_subprocess_stdout_using_utf8_encoded_linefeed(self):
-        """ Verify the assumption that subprocess.Popen returns stdout as UTF-8 encoded byte array
+    def test_split_subprocess_stdout_should_be_byte_array(self):
+        """ This test documents the following assumptions
+            - subprocess.Popen returns stdout as byte array and
+            - the encoding is given in sys.stdout.encoding
         """
         process_stdout = subprocess.Popen(["echo", "first line\nsecond line"], stdout=subprocess.PIPE).communicate()[0]
 
-        lines = process_stdout.split('\n'.encode('UTF-8'))
+        lines = process_stdout.split('\n'.encode(sys.stdout.encoding))
 
         self.assertEqual(3, len(lines))
 
-    def test_read_revisions_matching_should_return_three_revisions(self):
+    def test_read_revisions_matching_should_return_single_revision(self):
         expected_revision = "d804759"
         fake_git_result = expected_revision + " Documented tree map visualizations"
         fake_git_cmd = ['echo', fake_git_result]

--- a/miner/git_interactions_test.py
+++ b/miner/git_interactions_test.py
@@ -1,5 +1,6 @@
 import unittest
 import subprocess
+import git_interactions
 
 
 class GitInteractionsTest(unittest.TestCase):
@@ -8,9 +9,18 @@ class GitInteractionsTest(unittest.TestCase):
         """
         process_stdout = subprocess.Popen(["echo", "first line\nsecond line"], stdout=subprocess.PIPE).communicate()[0]
 
-        lines = process_stdout.split("\n".encode('UTF-8'))
+        lines = process_stdout.split('\n'.encode('UTF-8'))
 
         self.assertEqual(3, len(lines))
+
+    def test_read_revisions_matching_should_return_three_revisions(self):
+        expected_revision = "d804759"
+        fake_git_result = expected_revision + " Documented tree map visualizations"
+        fake_git_cmd = ['echo', fake_git_result]
+
+        actual = git_interactions._read_revisions_matching(fake_git_cmd)
+
+        self.assertEqual([expected_revision], actual)
 
 
 if __name__ == '__main__':

--- a/miner/git_interactions_test.py
+++ b/miner/git_interactions_test.py
@@ -1,12 +1,17 @@
 import unittest
 import subprocess
 
+
 class GitInteractionsTest(unittest.TestCase):
-    def test_reproduce_problem(self):
-        process_stdout = subprocess.Popen([ "echo", "first line\nsecond line" ], stdout=subprocess.PIPE).communicate()[0]
-        
-        lines = process_stdout.split("\n")
-        self.assertEqual(1, len(lines))
+    def test_split_subprocess_stdout_using_utf8_encoded_linefeed(self):
+        """ Verify the assumption that subprocess.Popen returns stdout as UTF-8 encoded byte array
+        """
+        process_stdout = subprocess.Popen(["echo", "first line\nsecond line"], stdout=subprocess.PIPE).communicate()[0]
+
+        lines = process_stdout.split("\n".encode('UTF-8'))
+
+        self.assertEqual(3, len(lines))
+
 
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
## Summary

In Python3 subprocess.POpen(...).communicate[0] returns a byte array instead of string.
As a consequence, `git_complexity_trend.py` reports an error.

This fix ensures that the messages from the `git` subprocess are converted to string
before they are returned to the caller.

In addition, the fix brings some unit tests for the scenario.