### PR TITLE
feat: properly sort merge commits and ordinary commits

### DIFF
--- a/combine-repos/commit.py
+++ b/combine-repos/commit.py
@@ -61,4 +61,7 @@ class Commit:
         return representation
 
     def __str__(self) -> str:
-        return self.first_line + '\n' + '\n'.join(self.change_lines)
+        result = self.first_line
+        if len(self.change_lines) > 0:
+            result += '\n' + '\n'.join(self.change_lines)
+        return  result

--- a/combine-repos/commit.py
+++ b/combine-repos/commit.py
@@ -48,6 +48,12 @@ class Commit:
     def change_lines(self):
         del self._change_lines
 
+    @property
+    def is_merge(self):
+        # merge commits can be recognized by not having the numstat entry,
+        # i.e. the change records in the change_lines property are empty
+        return len(self.change_lines) == 0
+
     def __eq__(self, other):
         if not isinstance(other, Commit):
             return False
@@ -62,6 +68,8 @@ class Commit:
 
     def __str__(self) -> str:
         result = self.first_line
-        if len(self.change_lines) > 0:
+
+        if not self.is_merge:
             result += '\n' + '\n'.join(self.change_lines)
+
         return  result

--- a/combine-repos/commit_history_reader.py
+++ b/combine-repos/commit_history_reader.py
@@ -31,9 +31,26 @@ class CommitHistoryReader:
         commit_groups = []
         current_commit_group = []
         for line in lines:
-            if line != '':
+            if len(current_commit_group) == 0:
+                # This is the first line of the file or after the previous commit group has been closed.
+                # This line is (usually) not empty but the header of the next commit.
                 current_commit_group.append(line)
+
+            elif line != '' and line[0] != '[':
+                # This is the "numstat" line for a file modified in the commit.
+                current_commit_group.append(line)
+
+            elif line != '' and line[0] == '[':
+                # The opening bracket shows that this is a new commit.
+                # Having no blank line between this commit and the previous commit
+                # shows that the previous commit was a merge commit.
+                # This implies that the previous commit should not have any file modifications.
+                commit_groups.append(current_commit_group)
+                current_commit_group = [line]
+
             else:
+                # This is a blank line.
+                # Blank lines separate an ordinary commit from the next commit.
                 commit_groups.append(current_commit_group)
                 current_commit_group = []
 

--- a/combine-repos/commit_history_report.py
+++ b/combine-repos/commit_history_report.py
@@ -9,10 +9,7 @@ class CommitHistoryReport:
         for commit in commits[:-1]:
             lines.append(str(commit))
 
-            # Only insert the blank line, if the current commit is not a merge commit
-            # merge commits can be recognized by not having the numstat entry - i.e. the change records in
-            # the change_lines property
-            if len(commit.change_lines) > 0:
+            if not commit.is_merge:
                 lines.append('')
 
         lines.append(str(commits[-1]))

--- a/combine-repos/commit_history_report.py
+++ b/combine-repos/commit_history_report.py
@@ -8,7 +8,12 @@ class CommitHistoryReport:
         lines = []
         for commit in commits[:-1]:
             lines.append(str(commit))
-            lines.append('')
+
+            # Only insert the blank line, if the current commit is not a merge commit
+            # merge commits can be recognized by not having the numstat entry - i.e. the change records in
+            # the change_lines property
+            if len(commit.change_lines) > 0:
+                lines.append('')
 
         lines.append(str(commits[-1]))
         return '\n'.join(lines)

--- a/combine-repos/test-data/merge-commits/combined_evo.log
+++ b/combine-repos/test-data/merge-commits/combined_evo.log
@@ -1,0 +1,52 @@
+[163844df] HospitalRun Bot 2020-03-07 Merge branch 'master' into dependabot/npm_and_yarn/react-bootstrap-typeahead-4.0.0
+[1b3ea025] First User 2020-03-07 Merge pull request #1883 from seconduser/master
+[0c87e13] HospitalRun Bot 2020-03-07 Merge branch 'master' into feature/table
+[b107a9e] dependabot-preview[bot] 2020-03-07 Merge pull request #316 from HospitalRun/dependabot/npm_and_yarn/react-datepicker-2.14.0
+[e7e9fab] dependabot-preview[bot] 2020-03-07 chore(deps): bump react-datepicker from 2.13.0 to 2.14.0
+1	1	components/package.json
+
+[a4e7e32] Stefano Casasola 2020-03-07 Merge branch 'master' into feature/table
+[62e691a] Stefano Casasola 2020-03-07 refactor(table): adds typings, code cleaning
+10	9	components/src/components/Table/Table.tsx
+29	58	components/src/components/Table/helper.tsx
+32	70	components/src/components/Table/interfaces.ts
+3	94	components/stories/table.stories.tsx
+
+[0aed460] Matteo Vivona 2020-03-07 Merge pull request #315 from HospitalRun/dependabot/npm_and_yarn/react-docgen-typescript-loader-3.7.0
+[54cf397] dependabot-preview[bot] 2020-03-07 chore(deps-dev): bump react-docgen-typescript-loader from 3.6.0 to 3.7.0
+1	1	components/package.json
+
+[d7a36ab2] HospitalRun Bot 2020-03-06 Merge branch 'master' into dependabot/npm_and_yarn/react-bootstrap-typeahead-4.0.0
+[60f8f10e] HospitalRun Bot 2020-03-06 Merge branch 'master' into master
+[3da7a9d2] dependabot-preview[bot] 2020-03-06 Merge pull request #1885 from HospitalRun/dependabot/npm_and_yarn/types/node-13.9.0
+[0ffecd1f] dependabot-preview[bot] 2020-03-06 chore(deps-dev): bump @types/node from 13.7.7 to 13.9.0
+1	1	frontend/package.json
+
+[ac67697b] HospitalRun Bot 2020-03-06 Merge branch 'master' into dependabot/npm_and_yarn/react-bootstrap-typeahead-4.0.0
+[c7a53adf] HospitalRun Bot 2020-03-06 Merge branch 'master' into master
+[5eeef892] Third User 2020-03-06 test(eslintrc): remove createDefaultProgram and update jest config
+3	4	frontend/.eslintrc.js
+2	1	frontend/jest.config.js
+1	1	frontend/package.json
+
+[fe408de7] HospitalRun Bot 2020-03-06 Merge branch 'master' into master
+[408451de] HospitalRun Bot 2020-03-06 Merge branch 'master' into dependabot/npm_and_yarn/react-bootstrap-typeahead-4.0.0
+[49e6098b] dependabot-preview[bot] 2020-03-06 Merge pull request #1884 from HospitalRun/dependabot/npm_and_yarn/hospitalrun/components-0.35.0
+[329f0c81] dependabot-preview[bot] 2020-03-06 chore(deps): bump @hospitalrun/components from 0.34.1 to 0.35.0
+1	1	frontend/package.json
+
+[168a1128] seconduser 2020-03-06 feat: making sidebar collapsible
+7	1	frontend/src/HospitalRun.tsx
+15	0	frontend/src/__tests__/HospitalRun.test.tsx
+20	10	frontend/src/__tests__/components/Sidebar.test.tsx
+23	4	frontend/src/components/Sidebar.tsx
+28	0	frontend/src/components/component-slice.ts
+1	1	frontend/src/index.css
+2	0	frontend/src/store/index.ts
+
+[8027f17] Matteo Vivona 2020-03-06 Merge branch 'master' into feature/table
+[57158fd] Matteo Vivona 2020-03-06 Merge pull request #309 from HospitalRun/dependabot/npm_and_yarn/react-bootstrap-typeahead-4.0.0
+[3d7649f] Stefano Casasola 2020-03-06 test(table): adds more table tests
+24	4	components/src/components/Table/Table.tsx
+91	0	components/stories/table.stories.tsx
+270	13	components/test/table.test.tsx

--- a/combine-repos/test-data/merge-commits/first_evo.log
+++ b/combine-repos/test-data/merge-commits/first_evo.log
@@ -1,0 +1,29 @@
+[163844df] HospitalRun Bot 2020-03-07 Merge branch 'master' into dependabot/npm_and_yarn/react-bootstrap-typeahead-4.0.0
+[1b3ea025] First User 2020-03-07 Merge pull request #1883 from seconduser/master
+[d7a36ab2] HospitalRun Bot 2020-03-06 Merge branch 'master' into dependabot/npm_and_yarn/react-bootstrap-typeahead-4.0.0
+[60f8f10e] HospitalRun Bot 2020-03-06 Merge branch 'master' into master
+[3da7a9d2] dependabot-preview[bot] 2020-03-06 Merge pull request #1885 from HospitalRun/dependabot/npm_and_yarn/types/node-13.9.0
+[0ffecd1f] dependabot-preview[bot] 2020-03-06 chore(deps-dev): bump @types/node from 13.7.7 to 13.9.0
+1	1	frontend/package.json
+
+[ac67697b] HospitalRun Bot 2020-03-06 Merge branch 'master' into dependabot/npm_and_yarn/react-bootstrap-typeahead-4.0.0
+[c7a53adf] HospitalRun Bot 2020-03-06 Merge branch 'master' into master
+[5eeef892] Third User 2020-03-06 test(eslintrc): remove createDefaultProgram and update jest config
+3	4	frontend/.eslintrc.js
+2	1	frontend/jest.config.js
+1	1	frontend/package.json
+
+[fe408de7] HospitalRun Bot 2020-03-06 Merge branch 'master' into master
+[408451de] HospitalRun Bot 2020-03-06 Merge branch 'master' into dependabot/npm_and_yarn/react-bootstrap-typeahead-4.0.0
+[49e6098b] dependabot-preview[bot] 2020-03-06 Merge pull request #1884 from HospitalRun/dependabot/npm_and_yarn/hospitalrun/components-0.35.0
+[329f0c81] dependabot-preview[bot] 2020-03-06 chore(deps): bump @hospitalrun/components from 0.34.1 to 0.35.0
+1	1	frontend/package.json
+
+[168a1128] seconduser 2020-03-06 feat: making sidebar collapsible
+7	1	frontend/src/HospitalRun.tsx
+15	0	frontend/src/__tests__/HospitalRun.test.tsx
+20	10	frontend/src/__tests__/components/Sidebar.test.tsx
+23	4	frontend/src/components/Sidebar.tsx
+28	0	frontend/src/components/component-slice.ts
+1	1	frontend/src/index.css
+2	0	frontend/src/store/index.ts

--- a/combine-repos/test-data/merge-commits/second_evo.log
+++ b/combine-repos/test-data/merge-commits/second_evo.log
@@ -1,0 +1,22 @@
+[0c87e13] HospitalRun Bot 2020-03-07 Merge branch 'master' into feature/table
+[b107a9e] dependabot-preview[bot] 2020-03-07 Merge pull request #316 from HospitalRun/dependabot/npm_and_yarn/react-datepicker-2.14.0
+[e7e9fab] dependabot-preview[bot] 2020-03-07 chore(deps): bump react-datepicker from 2.13.0 to 2.14.0
+1	1	components/package.json
+
+[a4e7e32] Stefano Casasola 2020-03-07 Merge branch 'master' into feature/table
+[62e691a] Stefano Casasola 2020-03-07 refactor(table): adds typings, code cleaning
+10	9	components/src/components/Table/Table.tsx
+29	58	components/src/components/Table/helper.tsx
+32	70	components/src/components/Table/interfaces.ts
+3	94	components/stories/table.stories.tsx
+
+[0aed460] Matteo Vivona 2020-03-07 Merge pull request #315 from HospitalRun/dependabot/npm_and_yarn/react-docgen-typescript-loader-3.7.0
+[54cf397] dependabot-preview[bot] 2020-03-07 chore(deps-dev): bump react-docgen-typescript-loader from 3.6.0 to 3.7.0
+1	1	components/package.json
+
+[8027f17] Matteo Vivona 2020-03-06 Merge branch 'master' into feature/table
+[57158fd] Matteo Vivona 2020-03-06 Merge pull request #309 from HospitalRun/dependabot/npm_and_yarn/react-bootstrap-typeahead-4.0.0
+[3d7649f] Stefano Casasola 2020-03-06 test(table): adds more table tests
+24	4	components/src/components/Table/Table.tsx
+91	0	components/stories/table.stories.tsx
+270	13	components/test/table.test.tsx

--- a/combine-repos/test_combine_repos.py
+++ b/combine-repos/test_combine_repos.py
@@ -53,7 +53,11 @@ class CombineReposTest(unittest.TestCase):
 
             TestCase(self, "multiple commits per file => result is sorted by date descending",
                      ["test-data/sort/first_evo.log", "test-data/sort/second_evo.log"],
-                     "test-data/sort/combined_evo.log")
+                     "test-data/sort/combined_evo.log"),
+
+            TestCase(self, "merge commits and ordinary commits => sorting rearranges both commit types",
+                     ["test-data/merge-commits/first_evo.log", "test-data/merge-commits/second_evo.log"],
+                     "test-data/merge-commits/combined_evo.log")
         ]
 
         self.maxDiff = None

--- a/combine-repos/test_commit_date_returns_none.py
+++ b/combine-repos/test_commit_date_returns_none.py
@@ -6,7 +6,7 @@ from commit import Commit
 
 
 @ddt.ddt
-class CommitHistoryReaderDateReturnsNoneTest(unittest.TestCase):
+class CommitDateReturnsNoneTest(unittest.TestCase):
     def setUp(self):
         self.commit = Commit()
 

--- a/combine-repos/test_commit_date_returns_valid_date.py
+++ b/combine-repos/test_commit_date_returns_valid_date.py
@@ -6,7 +6,7 @@ from datetime import date
 
 
 @ddt.ddt
-class CommitHistoryReaderDateReturnsValidDateTest(unittest.TestCase):
+class CommitDateReturnsValidDateTest(unittest.TestCase):
     def setUp(self):
         self.commit = Commit()
 

--- a/combine-repos/test_commit_history_report.py
+++ b/combine-repos/test_commit_history_report.py
@@ -39,6 +39,25 @@ class CommitHistoryReportTest(unittest.TestCase):
 
         self.assertEqual('\n'.join(expected), actual)
 
+    def test_given_merge_commit_and_ordinary_commit_when_print_then_no_blank_line_between_commits(self):
+        merge_commit = Commit()
+        merge_commit.first_line = "[1234567] Some Author 2022-04-26 This is a merge commit"
+        merge_commit.change_lines = []
+
+        ordinary_commit = self.create_commit()
+
+        commits = [merge_commit, ordinary_commit]
+
+        sut = CommitHistoryReport()
+        actual = sut.generate(commits)
+
+        expected = [merge_commit.first_line]
+
+        expected.append(ordinary_commit.first_line)
+        expected += ordinary_commit.change_lines
+
+        self.assertEqual('\n'.join(expected), actual)
+
     @staticmethod
     def create_commit():
         result = Commit()

--- a/combine-repos/test_commit_str.py
+++ b/combine-repos/test_commit_str.py
@@ -1,0 +1,26 @@
+import unittest
+
+from commit import Commit
+
+
+class CommitStrTest(unittest.TestCase):
+    def test_given_commit_and_change_line_when_str_then_return_two_lined_string(self):
+        commit = Commit()
+        commit.first_line = '[1234567] Some Author 2022-05-09 Some comment'
+        commit.change_lines = ['1\t2\tsome_file.txt']
+
+        actual = str(commit)
+
+        expected = '[1234567] Some Author 2022-05-09 Some comment\n' \
+                   '1\t2\tsome_file.txt'
+        self.assertEqual(expected, actual)
+
+    def test_given_commit_without_change_line_when_str_then_return_single_line_string(self):
+        commit = Commit()
+        commit.first_line = '[1234567] Some Author 2022-05-09 Some comment'
+        commit.change_lines = []
+
+        actual = str(commit)
+
+        expected = '[1234567] Some Author 2022-05-09 Some comment'
+        self.assertEqual(expected, actual)


### PR DESCRIPTION
Fix: The current status processes merge commits followed by an ordinary commit like a single commit, where the commit messages of the ordinary commit is considered a file change.